### PR TITLE
Send data via POST body instead of params

### DIFF
--- a/lib/profitwell/modules/transaction.rb
+++ b/lib/profitwell/modules/transaction.rb
@@ -7,14 +7,17 @@ class Profitwell::Client
     end
 
     def new_customer(email, plan_name, plan_interval, plan_value, start_date, options={})
+      data = {
+          'email' => email,
+          'plan_name' => plan_name,
+          'plan_interval' => plan_interval,
+          'plan_value' => plan_value,
+          'start_date' => start_date
+      }
+      data['currency'] = options['currency'] unless options['currency'].nil?
+      data['end_date'] = options['end_date'] unless options['end_date'].nil?
       customer = connection.post('transactions/') do |req|
-        req.params['email'] = email
-        req.params['plan_name'] = plan_name
-        req.params['plan_interval'] = plan_interval
-        req.params['plan_value'] = plan_value
-        req.params['start_date'] = start_date
-        req.params['currency'] = options['currency'] unless options['currency'].nil?
-        req.params['end_date'] = options['end_date'] unless options['end_date'].nil?
+        req.body = data.to_json
       end
       parse_response(customer)
     end

--- a/lib/profitwell/modules/transaction_detail.rb
+++ b/lib/profitwell/modules/transaction_detail.rb
@@ -7,11 +7,14 @@ class Profitwell::Client
     end
 
     def update_subscription(user_id, plan_name, plan_interval, plan_value, start_date)
+      data = {
+          'plan_name' => plan_name,
+          'plan_interval' => plan_interval,
+          'plan_value' => plan_value,
+          'start_date' => start_date
+      }
       update_response = connection.post("transactions/user/#{user_id}/") do |req|
-        req.params['plan_name'] = plan_name
-        req.params['plan_interval'] = plan_interval
-        req.params['plan_value'] = plan_value
-        req.params['start_date'] = start_date
+        req.body = data.to_json
       end
       parse_response(update_response)
     end


### PR DESCRIPTION
When I was attempting to send POST calls using the params I was receiving a 500 error.

As of today, it looks like the Profitwell v1 API requires POST data to be sent over in the body instead of the params. (https://profitwell.docs.apiary.io/#reference/endpoints/transactions/add-a-new-user)
